### PR TITLE
Fix label miss-matches for P6271 and P9970

### DIFF
--- a/conf/conf.sample.php
+++ b/conf/conf.sample.php
@@ -29,8 +29,8 @@ define('LEXEMES_SITE_DIR', 'lexemes/');
 define('LEXEMES_CHALLENGE_TWEETS', false);
 define('LEXEMES_CHALLENGE_PROPERTIES', array(
     'P5137' => 'item for this sense',
-    'P6271' => 'predicate for',
-    'P9970' => 'demonym of',
+    'P6271' => 'demonym of',
+    'P9970' => 'predicate for',
 ));
 
 define('NOMS_SITE_DIR', 'noms/');


### PR DESCRIPTION
Remainder: don't forget to update config on toolforge as well.